### PR TITLE
Bring over competition changes

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -23,7 +23,7 @@ public final class Constants {
     public static final int kRightMotor2Port = 4;
 
     public static final int kEncoderCPR = 1024;
-    public static final double kWheelDiameterInches = 6;
+    public static final double kWheelDiameterInches = .152;
     public static final double kEncoderDistancePerPulse =
         // Assumes the encoders are directly mounted on the wheel shafts
         (kWheelDiameterInches * Math.PI) / (double) kEncoderCPR;

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -22,7 +22,7 @@ public final class Constants {
     public static final int kRightMotor1Port = 2;
     public static final int kRightMotor2Port = 4;
 
-    public static final int kEncoderCPR = 1024;
+    public static final int kEncoderCPR = 4096;
     public static final double kWheelDiameterInches = .152;
     public static final double kEncoderDistancePerPulse =
         // Assumes the encoders are directly mounted on the wheel shafts

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -142,14 +142,14 @@ public class RobotContainer {
     
     // Slowness II
     m_controller_main.leftTrigger
-      .whenPressed(() -> m_drivetrain.setSpeedMultiplier(OIConstants.kBaseDriveSpeedMult/1.3))//adjust slow speed
+      .whenPressed(() -> m_drivetrain.setSpeedMultiplier(OIConstants.kBaseDriveSpeedMult*0.6))//adjust slow speed
       .whenReleased(() -> m_drivetrain.setSpeedMultiplier(OIConstants.kBaseDriveSpeedMult));
 
     m_controller_main.a
-      .whenPressed(new ModifiedAim(m_drivetrain, m_limelight));
+      .whileHeld(new ModifiedAim(m_drivetrain, m_limelight));
 
     m_controller_main.b
-      .whenPressed(new ModifiedRange(m_drivetrain, m_limelight, 3.31));
+      .whileHeld(new ModifiedRange(m_drivetrain, m_limelight, 3.31));
 
     // Control the launcher via right trigger
     m_controller_aux.rightTrigger

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -32,7 +32,7 @@ import frc.robot.commands.limelight.ModifiedRange;
 import frc.robot.commands.climber.LowerMast;
 import frc.robot.commands.climber.RaiseMast;
 import frc.robot.commands.climber.ToggleHook;
-import frc.robot.commands.climber.TomahawkDown;
+import frc.robot.commands.climber.TomahawkMove;
 import frc.robot.commands.climber.TomahawkUp;
 import frc.robot.commands.drivetrain.ArcadeDrive;
 import frc.robot.commands.drivetrain.DriveStraight;
@@ -134,25 +134,29 @@ public class RobotContainer {
 
     m_drivetrain.setDefaultCommand(
       new ArcadeDrive(m_controller_main::getLeftStickY, m_controller_main::getRightStickX, m_drivetrain));
+    
+    m_climber.setDefaultCommand(
+      new TomahawkMove(m_controller_aux::getRightStickX, m_climber)
+    );
 
+    
     // Slowness II
     m_controller_main.leftTrigger
-      .whenPressed(() -> m_drivetrain.setSpeedMultiplier(OIConstants.kBaseDriveSpeedMult/1.5))//adjust slow speed
+      .whenPressed(() -> m_drivetrain.setSpeedMultiplier(OIConstants.kBaseDriveSpeedMult/1.3))//adjust slow speed
       .whenReleased(() -> m_drivetrain.setSpeedMultiplier(OIConstants.kBaseDriveSpeedMult));
 
     m_controller_main.a
       .whenPressed(new ModifiedAim(m_drivetrain, m_limelight));
-    
-    // Limelight trigger
-    // m_controller_main.rightTrigger
-    //   .whileHeld();
+
+    m_controller_main.b
+      .whenPressed(new ModifiedRange(m_drivetrain, m_limelight, 3.31));
 
     // Control the launcher via right trigger
     m_controller_aux.rightTrigger
-      .whileHeld(new RunLauncher(m_launcher, -0.75));
+      .whileHeld(new RunLauncher(m_launcher, -0.725));
 
     m_controller_aux.leftTrigger
-      .whileHeld(new SpitBall(m_intake));
+      .whileHeld(new RunLauncher(m_launcher, -0.65));
 
     m_controller_aux.rightBumper
       .whileHeld(new ShootBall(m_feeder));
@@ -163,23 +167,23 @@ public class RobotContainer {
     m_controller_aux.bottomDPAD
       .whileHeld(new LowerMast(m_climber));
     
-    m_controller_aux.leftDPAD
-      .whileHeld(new TomahawkDown(m_climber));
+    //m_controller_aux.leftDPAD
+      //.whileHeld(new TomahawkDown(m_climber));
 
-    m_controller_aux.rightDPAD
-      .whileHeld(new TomahawkUp(m_climber));
+    //m_controller_aux.rightDPAD
+      //.whileHeld(new TomahawkUp(m_climber));
 
     m_controller_aux.a
       .toggleWhenPressed(new PickUp(m_intake));
     
     m_controller_aux.b
-      .whileHeld(new RunLauncher(m_launcher,-0.1));
+      .whileHeld(new SpitBall(m_intake));
 
     m_controller_aux.x  
       .whenPressed(new ToggleHook(m_climber));
 
     m_controller_aux.y  
-      .whenPressed(new ReverseFeedLauncherWheel(m_launcher,m_feeder));
+      .whileHeld(new ReverseFeedLauncherWheel(m_launcher,m_feeder));
 
   }
 
@@ -195,7 +199,7 @@ public class RobotContainer {
     m_autoChooser.addOption("Aim and Range", new AimRange(m_drivetrain, m_limelight,1.2192));//number got by looking at limelight distance and pushing it against the hub -.1 meter
     m_autoChooser.addOption("Auto PickUp", new AutoPickUp(m_intake, m_drivetrain, 0.5842));
     m_autoChooser.addOption("Auto Shoot", new AutoShootBall(m_launcher, m_feeder, m_limelight));
-    m_autoChooser.addOption("Drive Straight", new DriveStraight(.055, m_drivetrain));
+    m_autoChooser.addOption("Drive Straight", new DriveStraight(2.5, m_drivetrain));
 
     //Creates new Shuffleboard tab called Drivebase
     ShuffleboardTab testTab = Shuffleboard.getTab("Drivebase");

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -139,6 +139,9 @@ public class RobotContainer {
     m_controller_main.leftTrigger
       .whenPressed(() -> m_drivetrain.setSpeedMultiplier(OIConstants.kBaseDriveSpeedMult/1.5))//adjust slow speed
       .whenReleased(() -> m_drivetrain.setSpeedMultiplier(OIConstants.kBaseDriveSpeedMult));
+
+    m_controller_main.a
+      .whenPressed(new ModifiedAim(m_drivetrain, m_limelight));
     
     // Limelight trigger
     // m_controller_main.rightTrigger
@@ -146,7 +149,7 @@ public class RobotContainer {
 
     // Control the launcher via right trigger
     m_controller_aux.rightTrigger
-      .whileHeld(new RunLauncher(m_launcher, -0.60));
+      .whileHeld(new RunLauncher(m_launcher, -0.75));
 
     m_controller_aux.leftTrigger
       .whileHeld(new SpitBall(m_intake));
@@ -187,12 +190,12 @@ public class RobotContainer {
     //m_autoChooser.addOption("Left Auto", AutoCommands.LeftAuto);
     //m_autoChooser.addOption("Middle Auto", AutoCommands.MiddleAuto);
     //m_autoChooser.addOption("Right Auto", AutoCommands.RightAuto);
-    m_autoChooser.addOption("Modified Range", new ModifiedRange(m_drivetrain, m_limelight, 1.2192));
+    m_autoChooser.addOption("Modified Range", new ModifiedRange(m_drivetrain, m_limelight, 2.5));
     m_autoChooser.addOption("Modified Aim", new ModifiedAim(m_drivetrain, m_limelight));
     m_autoChooser.addOption("Aim and Range", new AimRange(m_drivetrain, m_limelight,1.2192));//number got by looking at limelight distance and pushing it against the hub -.1 meter
     m_autoChooser.addOption("Auto PickUp", new AutoPickUp(m_intake, m_drivetrain, 0.5842));
     m_autoChooser.addOption("Auto Shoot", new AutoShootBall(m_launcher, m_feeder, m_limelight));
-    m_autoChooser.addOption("Drive Straight", new DriveStraight(-3.23, m_drivetrain));
+    m_autoChooser.addOption("Drive Straight", new DriveStraight(.055, m_drivetrain));
 
     //Creates new Shuffleboard tab called Drivebase
     ShuffleboardTab testTab = Shuffleboard.getTab("Drivebase");

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -33,7 +33,6 @@ import frc.robot.commands.climber.LowerMast;
 import frc.robot.commands.climber.RaiseMast;
 import frc.robot.commands.climber.ToggleHook;
 import frc.robot.commands.climber.TomahawkMove;
-import frc.robot.commands.climber.TomahawkUp;
 import frc.robot.commands.drivetrain.ArcadeDrive;
 import frc.robot.commands.drivetrain.DriveStraight;
 import frc.robot.commands.intake.PickUp;

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -99,7 +99,7 @@ public class RobotContainer {
       camera1.setPixelFormat(PixelFormat.kYUYV); //formats video specifications for cameras
 
       //Camera 2
-      camera2 = CameraServer.startAutomaticCapture("Climber", 1);
+      camera2 = CameraServer.startAutomaticCapture("Intake", 1);
       //camera2.setResolution(160, 120);
       camera2.setFPS(14);
       camera2.setPixelFormat(PixelFormat.kYUYV); //formats video specifications for cameras

--- a/src/main/java/frc/robot/commands/autonomous/AutoCommands.java
+++ b/src/main/java/frc/robot/commands/autonomous/AutoCommands.java
@@ -81,10 +81,8 @@ public class AutoCommands {
         );
 
         ModifiedGeneralAuto = new SequentialCommandGroup(
-            new ModifiedRange(drivetrain, limelight, 1.2192),
-            new ModifiedAim(drivetrain, limelight),
             new AutoShootBall(launcher, feeder, limelight),
-            new DriveStraight(-3.3, drivetrain)
+            new DriveStraight(2.5, drivetrain)
         );
 
         

--- a/src/main/java/frc/robot/commands/autonomous/AutoShootBall.java
+++ b/src/main/java/frc/robot/commands/autonomous/AutoShootBall.java
@@ -40,7 +40,7 @@ public class AutoShootBall extends ParallelCommandGroup {
   // Note, would be better if launcher speed can be inputed with neededVelocity
   @Override
   public void execute() {
-    m_launcher.setSpeed(-.6);
+    m_launcher.setSpeed(-.75);
     
     if(Timer.getFPGATimestamp() - startTime >= 2){
       m_feeder.setSpeed(1);
@@ -58,6 +58,6 @@ public class AutoShootBall extends ParallelCommandGroup {
   // Scuffed is finished, need to rethink
   @Override
   public boolean isFinished() {
-    return (Timer.getFPGATimestamp() - startTime >= 2.1);
+    return (Timer.getFPGATimestamp() - startTime >= 2.3);
   }
 }

--- a/src/main/java/frc/robot/commands/autonomous/AutoShootBall.java
+++ b/src/main/java/frc/robot/commands/autonomous/AutoShootBall.java
@@ -58,6 +58,6 @@ public class AutoShootBall extends ParallelCommandGroup {
   // Scuffed is finished, need to rethink
   @Override
   public boolean isFinished() {
-    return (Timer.getFPGATimestamp() - startTime >= 2.3);
+    return (Timer.getFPGATimestamp() - startTime >= 2.5);
   }
 }

--- a/src/main/java/frc/robot/commands/autonomous/AutoShootBall.java
+++ b/src/main/java/frc/robot/commands/autonomous/AutoShootBall.java
@@ -40,7 +40,7 @@ public class AutoShootBall extends ParallelCommandGroup {
   // Note, would be better if launcher speed can be inputed with neededVelocity
   @Override
   public void execute() {
-    m_launcher.setSpeed(-.75);
+    m_launcher.setSpeed(-.65);
     
     if(Timer.getFPGATimestamp() - startTime >= 2){
       m_feeder.setSpeed(1);

--- a/src/main/java/frc/robot/commands/climber/TomahawkMove.java
+++ b/src/main/java/frc/robot/commands/climber/TomahawkMove.java
@@ -1,27 +1,28 @@
 package frc.robot.commands.climber;
 
+import java.util.function.DoubleSupplier;
+
 import edu.wpi.first.wpilibj2.command.CommandBase;
 import frc.robot.subsystems.Climber;
 
-public class TomahawkDown extends CommandBase {
+public class TomahawkMove extends CommandBase {
     private final Climber m_climber;
+    private DoubleSupplier m_speed;
 
-    public TomahawkDown(Climber climber) {
+    public TomahawkMove(DoubleSupplier speed, Climber climber) {
         m_climber = climber;
+        m_speed = speed;
         // Use addRequirements() here to declare subsystem dependencies.
         addRequirements(climber);
-    }
-
-    // Called when the command is initially scheduled.
-    @Override
-    public void initialize() {
-        m_climber.setClimberMotorSpeed(0);
     }
   
     // Called every time the scheduler runs while the command is scheduled.
     @Override
     public void execute() {
-        m_climber.setClimberMotorSpeed(-0.75); //may need to adjust based on motor
+        double inputSpeed = m_speed.getAsDouble();
+        inputSpeed = ((Math.abs(inputSpeed) < .1) ? 0 : inputSpeed);
+
+        m_climber.setClimberMotorSpeed(inputSpeed); //may need to adjust based on motor
     }
   
     // Called once the command ends or is interrupted.

--- a/src/main/java/frc/robot/commands/drivetrain/ArcadeDrive.java
+++ b/src/main/java/frc/robot/commands/drivetrain/ArcadeDrive.java
@@ -34,7 +34,7 @@ public class ArcadeDrive extends CommandBase {
   @Override
   public void execute() {
     double xaxisSpeed = m_xaxisSpeedSupplier.getAsDouble();
-    double zaxisSpeed = m_zaxisRotateSuppplier.getAsDouble();
+    double zaxisSpeed = m_zaxisRotateSuppplier.getAsDouble() * .9;
 
     if(Math.abs(xaxisSpeed) < 0.2) {
         xaxisSpeed = 0;
@@ -44,7 +44,7 @@ public class ArcadeDrive extends CommandBase {
         zaxisSpeed = 0;
     }
 
-    m_drivetrain.arcadeDrive(xaxisSpeed,    zaxisSpeed);
+    m_drivetrain.arcadeDrive(xaxisSpeed, zaxisSpeed);
   }
 
   // Called once after isFinished returns true

--- a/src/main/java/frc/robot/commands/drivetrain/DriveStraight.java
+++ b/src/main/java/frc/robot/commands/drivetrain/DriveStraight.java
@@ -5,6 +5,7 @@
 package frc.robot.commands.drivetrain;
 
 import edu.wpi.first.math.controller.PIDController;
+import edu.wpi.first.wpilibj.Timer;
 import edu.wpi.first.wpilibj2.command.PIDCommand;
 import frc.robot.subsystems.DriveTrain;
 
@@ -15,6 +16,7 @@ import frc.robot.subsystems.DriveTrain;
  */
 public class DriveStraight extends PIDCommand {
   private final DriveTrain m_drivetrain;
+  private double startTime;
 
   /**
    * Create a new DriveStraight command.
@@ -29,13 +31,14 @@ public class DriveStraight extends PIDCommand {
     m_drivetrain.reset();
     addRequirements(m_drivetrain);
 
-    getController().setTolerance(0.1);
+    getController().setTolerance(1);
   }
 
   // Called just before this Command runs the first time
   @Override
   public void initialize() {
     // Get everything in a safe starting state.
+    startTime = Timer.getFPGATimestamp();
     m_drivetrain.reset();
     super.initialize();
   }
@@ -43,6 +46,6 @@ public class DriveStraight extends PIDCommand {
   // Make this return true when this Command no longer needs to run execute()
   @Override
   public boolean isFinished() {
-    return getController().atSetpoint();
+    return (Timer.getFPGATimestamp() - startTime >= 1);
   }
 }

--- a/src/main/java/frc/robot/commands/drivetrain/DriveStraight.java
+++ b/src/main/java/frc/robot/commands/drivetrain/DriveStraight.java
@@ -23,13 +23,13 @@ public class DriveStraight extends PIDCommand {
    */
   public DriveStraight(double distance, DriveTrain drivetrain) {
     super(
-        new PIDController(4, 0, 0), drivetrain::getDistance, distance, d -> drivetrain.tankDrive(d, d));
+        new PIDController(3, 0, 0), drivetrain::getDistance, distance, d -> drivetrain.tankDrive(d, d));
 
     m_drivetrain = drivetrain;
     m_drivetrain.reset();
     addRequirements(m_drivetrain);
 
-    getController().setTolerance(0.01);
+    getController().setTolerance(0.1);
   }
 
   // Called just before this Command runs the first time

--- a/src/main/java/frc/robot/commands/intake/PickUp.java
+++ b/src/main/java/frc/robot/commands/intake/PickUp.java
@@ -40,7 +40,7 @@ public class PickUp extends CommandBase {
       m_intake.enableBouncer();
     }
 
-    m_intake.setSpeed(0.4);
+    m_intake.setSpeed(-0.6);
   }
 
   // Called once the command ends or is interrupted.
@@ -48,7 +48,7 @@ public class PickUp extends CommandBase {
   public void end(boolean interrupted) throws RuntimeException {
     m_intake.disableBouncer();
     m_intake.retract();
-    m_intake.setSpeed(0.25);
+    m_intake.setSpeed(-0.25);
   }
 
   // Returns true when the command should end.

--- a/src/main/java/frc/robot/commands/intake/PickUp.java
+++ b/src/main/java/frc/robot/commands/intake/PickUp.java
@@ -40,7 +40,7 @@ public class PickUp extends CommandBase {
       m_intake.enableBouncer();
     }
 
-    m_intake.setSpeed(-0.6);
+    m_intake.setSpeed(0.4);
   }
 
   // Called once the command ends or is interrupted.
@@ -48,7 +48,7 @@ public class PickUp extends CommandBase {
   public void end(boolean interrupted) throws RuntimeException {
     m_intake.disableBouncer();
     m_intake.retract();
-    m_intake.setSpeed(-0.45);
+    m_intake.setSpeed(0.25);
   }
 
   // Returns true when the command should end.

--- a/src/main/java/frc/robot/commands/intake/PickUp.java
+++ b/src/main/java/frc/robot/commands/intake/PickUp.java
@@ -40,7 +40,7 @@ public class PickUp extends CommandBase {
       m_intake.enableBouncer();
     }
 
-    m_intake.setSpeed(-0.75);
+    m_intake.setSpeed(-0.6);
   }
 
   // Called once the command ends or is interrupted.
@@ -48,7 +48,7 @@ public class PickUp extends CommandBase {
   public void end(boolean interrupted) throws RuntimeException {
     m_intake.disableBouncer();
     m_intake.retract();
-    m_intake.setSpeed(-0.65);
+    m_intake.setSpeed(-0.45);
   }
 
   // Returns true when the command should end.

--- a/src/main/java/frc/robot/commands/launcher/ReverseFeedLauncherWheel.java
+++ b/src/main/java/frc/robot/commands/launcher/ReverseFeedLauncherWheel.java
@@ -37,7 +37,7 @@ public class ReverseFeedLauncherWheel extends CommandBase {
   @Override
   public void execute() {
     m_launcher.setSpeed(.25);
-    m_feeder.setSpeed(.25);
+    m_feeder.setSpeed(-.25);
   }
 
   // Called once the command ends or is interrupted.

--- a/src/main/java/frc/robot/commands/launcher/RunLauncher.java
+++ b/src/main/java/frc/robot/commands/launcher/RunLauncher.java
@@ -30,14 +30,14 @@ public class RunLauncher extends CommandBase {
     m_launcher = launcher;
     this.speed = LauncherConstants.kLauncherSpeed.getDouble(0);
 
+    m_launcher.setSpeed(0.06);
+
     addRequirements(launcher);
   }
 
   // Called when the command is initially scheduled.
   @Override
   public void initialize() {
-
-
   }
 
   // Called every time the scheduler runs while the command is scheduled.
@@ -49,7 +49,7 @@ public class RunLauncher extends CommandBase {
   // Called once the command ends or is interrupted.
   @Override
   public void end(boolean interrupted) {
-    m_launcher.setSpeed(0);
+    m_launcher.setSpeed(0.06);
   }
 
   // Returns true when the command should end.

--- a/src/main/java/frc/robot/commands/launcher/ShootBall.java
+++ b/src/main/java/frc/robot/commands/launcher/ShootBall.java
@@ -20,6 +20,7 @@ public class ShootBall extends CommandBase {
     m_feeder = feeder;
     // Use addRequirements() here to declare subsystem dependencies.
     addRequirements(feeder);
+    m_feeder.setSpeed(-.06);
   }
 
   // Called when the command is initially scheduled.
@@ -36,6 +37,7 @@ public class ShootBall extends CommandBase {
   @Override
   public void end(boolean interrupted) {
     m_feeder.setSpeed(0);
+    m_feeder.setSpeed(-.06);
   }
 
   // Returns true when the command should end.

--- a/src/main/java/frc/robot/commands/limelight/ModifiedRange.java
+++ b/src/main/java/frc/robot/commands/limelight/ModifiedRange.java
@@ -75,7 +75,7 @@ public class ModifiedRange extends CommandBase {
     angleTolerance = 0.1;
     meterTolerance = 0.1;
     
-    minDriveSpeed = .345;
+    minDriveSpeed = .355;
   }
 
   // Called every time the scheduler runs while the command is scheduled.

--- a/src/main/java/frc/robot/subsystems/LimeLight.java
+++ b/src/main/java/frc/robot/subsystems/LimeLight.java
@@ -110,8 +110,6 @@ public class LimeLight extends SubsystemBase {
         double angleToTargetRadians = angleToTargetDegree * (Math.PI / 180);
 
         double distanceToTarget = (LimeLightConstants.kTargetHeight - LimeLightConstants.kLensHeight) / Math.tan(angleToTargetRadians);
-        distanceToTarget = ((isTargetFound() == false) ? 0 : distanceToTarget);
-
         return distanceToTarget;
     }
 
@@ -138,12 +136,20 @@ public class LimeLight extends SubsystemBase {
         return ((calculateLauncherVelocity() > LauncherConstants.kMaxVelocity) ? false : true);
     }
 
+    public boolean isTargetExistant(){
+        return ((getHorizontalDegToTarget() != 0) ? true : false);
+    }
+
+    public boolean isDistancePossible(){
+        return((estimateDistance() < 3.30 && estimateDistance() > 3.2) ? true : false);
+    }
+
     /**
      * 
      * @return whether or not shooting angle is possible
      */
     public boolean isAnglePossible(){
-        return ((Math.abs(getHorizontalDegToTarget()) > 5) ? false : true); // 5 Represents a degree tolerance for shooting
+        return ((Math.abs(getHorizontalDegToTarget()) > 2.30 || Math.abs(getHorizontalDegToTarget()) < 2.40) ? false : true); // 5 Represents a degree tolerance for shooting
     }
 
     /** The log method puts interesting information to the SmartDashboard. */
@@ -152,7 +158,9 @@ public class LimeLight extends SubsystemBase {
         SmartDashboard.putNumber("LimelightY", getVerticalDegToTarget());
         SmartDashboard.putNumber("LimelightArea", getTargetArea());
         SmartDashboard.putNumber("Limelight Distance", estimateDistance());
-        SmartDashboard.putBoolean("Is Target Found", isTargetFound());
+        SmartDashboard.putBoolean("Good Angle", isAnglePossible());
+        SmartDashboard.putBoolean("Good Distance", isDistancePossible());
+        SmartDashboard.putBoolean("Target Found", isTargetExistant());
         //SmartDashboard.putBoolean("Is Scorable", isVelocityPossible() && isAnglePossible());
     } 
 


### PR DESCRIPTION
**Changes made:**
- Encoder constants updated
- `TomahawkDown` renamed to `TomahawkMove` in order to use joystick
- Slow speed modifier set to 60%
- `ModifiedAim` and `ModifiedRange` bound to main controller `a` and `b`
- `SpitBall` bound to aux `b`
- `ReverseFeedLauncherWheel` changed to `whileHeld`
- `ModifiedGeneralAuto` tweaked
- `ModifiedRange` drive speed tweaked
- `AutoShootBall` tweaked
- Tweak `ArcadeDrive` rotation speed
- `DriveStraight` tweaked
- `PickUp` tweaked
- `RunLauncher` and `ShootBall` tweaked to always run wheels backwards when not triggered by controller
- Limelight indicators added for angle and distance
- Climber camera has moved to view Intake, so it has been renamed

Things can be cleaned up, such as now unused code, then can get merged to `main`